### PR TITLE
✨[Feat] MyRecruits 화면 — 빈 상태/일정/상태 연동 및 UI 정리

### DIFF
--- a/app/src/main/java/com/baek/untitledproject/data/model/mapper/PostMapper.kt
+++ b/app/src/main/java/com/baek/untitledproject/data/model/mapper/PostMapper.kt
@@ -120,30 +120,3 @@ fun PostResponse.toApplicationRequirement(customQuestions: List<CustomQuestionRe
             .map { CustomQuestion(questionId = it.question_id, questionText = it.question_text) }
     )
 }
-
-fun PostResponse.toMyRecruitSummary(
-    thumbnailUrl: String? = null,
-    applicantCount: Int = 0
-): MyRecruitSummary {
-    return MyRecruitSummary(
-        id = post_id,
-        title = title,
-        category = organization,
-        recruitStatus = mapPostStatusToText(status),
-        thumbnailUrl = thumbnailUrl,
-        hasInterview = has_interview,
-        applicantCount = applicantCount,
-        recruitmentEnd = recruitment_end?.toLocalDate()?.format(
-            DateTimeFormatter.ofPattern("MM/dd")
-        )
-    )
-}
-
-// 공고 상태를 한글로 변환
-private fun mapPostStatusToText(status: String): String {
-    return when (status) {
-        "recruiting" -> "모집중"
-        "completed" -> "모집완료"
-        else -> "알 수 없음"
-    }
-}

--- a/app/src/main/java/com/baek/untitledproject/data/remote/ApplicantRemote.kt
+++ b/app/src/main/java/com/baek/untitledproject/data/remote/ApplicantRemote.kt
@@ -8,18 +8,13 @@ import kotlinx.coroutines.tasks.await
 
 object ApplicantRemote {
 
-    private const val currentUserId = "author1" // 임시 하드코딩
-
-    /**
-     * 특정 공고의 지원자 목록 조회
-     */
-    suspend fun getApplicants(postId: String): List<ApplicantSummary> {
+    suspend fun getApplicants(postId: String, currentUserId: String): List<ApplicantSummary> {
         val db = FirebaseFirestore.getInstance()
 
         Log.d("ApplicantRemote", "currentUserId: $currentUserId")
 
         val applicationsSnap = db.collection("applications")
-            .whereEqualTo("post_id", "43470D45-5C9B-4B35-9F6A-452DC240D14D")
+            .whereEqualTo("post_id", postId)
             .whereEqualTo("post_author_user_id", currentUserId)
             .get()
             .await()
@@ -48,7 +43,7 @@ object ApplicantRemote {
                         data["status"] as? String ?: "submitted",
                         data["is_passed"] as? Boolean
                     ),
-                    customQuestionAnswers = emptyList() // 목록에서는 빈 리스트
+                    customQuestionAnswers = emptyList()
                 )
 
                 Log.d("ApplicantRemote", "변환 성공: ${applicant.name}, 상태: ${applicant.statusText}")
@@ -66,9 +61,6 @@ object ApplicantRemote {
         }
     }
 
-    /**
-     * 지원자 상세 정보 조회
-     */
     suspend fun getApplicantDetail(applicationId: String): ApplicantSummary {
         val db = FirebaseFirestore.getInstance()
 
@@ -149,14 +141,14 @@ object ApplicantRemote {
             hasSlots
         } catch (e: Exception) {
             Log.e("ApplicantRemote", "면접 슬롯 확인 실패: $postId", e)
-            false  // 에러 발생 시 false 반환 (안전한 기본값)
+            false
         }
     }
 
     /**
      * 지원자들을 면접 대기 상태로 변경 (면접 일정 체크 포함)
      */
-    suspend fun scheduleInterviews(applicationIds: List<String>) {
+    suspend fun scheduleInterviews(applicationIds: List<String>, currentUserId: String) {
         val db = FirebaseFirestore.getInstance()
 
         // 첫 번째 지원서를 통해 postId 확인
@@ -300,7 +292,7 @@ object ApplicantRemote {
     /**
      * 지원자들에게 결과 알림 발송
      */
-    suspend fun notifyResults(applicationIds: List<String>) {
+    suspend fun notifyResults(applicationIds: List<String>, currentUserId: String) {
         val db = FirebaseFirestore.getInstance()
 
         applicationIds.forEach { applicationId ->

--- a/app/src/main/java/com/baek/untitledproject/data/remote/MyRecruitsRemote.kt
+++ b/app/src/main/java/com/baek/untitledproject/data/remote/MyRecruitsRemote.kt
@@ -5,44 +5,50 @@ import com.baek.untitledproject.domain.data.AppliedRecruitSummary
 import com.baek.untitledproject.domain.data.MyRecruitSummary
 import com.baek.untitledproject.domain.data.ScheduleGroupSummary
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.FieldPath
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.tasks.await
-import java.text.SimpleDateFormat
-import java.util.*
+import java.time.LocalDate
+import com.baek.untitledproject.common.utils.toLocalDate
 
 object MyRecruitsRemote {
 
-    private const val myRecruitUserId = "test-author-123"
-    private const val myAppliedUserId = "user2"
-
-    suspend fun getMyRecruits(): List<MyRecruitSummary> {
+    suspend fun getMyRecruits(currentUserId: String): List<MyRecruitSummary> {
         val db = FirebaseFirestore.getInstance()
 
         val postsSnap = db.collection("posts")
-            .whereEqualTo("author_user_id", myRecruitUserId)
+            .whereEqualTo("author_user_id", currentUserId)
             .get()
             .await()
 
         val postIds = postsSnap.documents.map { it.id }
 
-        // 썸네일 이미지 조회
+        // 썸네일 맵
         val thumbMap = fetchThumbnailByPostId(db, postIds)
 
         return postsSnap.documents.mapNotNull { doc ->
             try {
-                val data = doc.data ?: return@mapNotNull null
+                val title = doc.getString("title") ?: "제목 없음"
+                val org = doc.getString("organization") ?: "단체명 없음"
+                val status = getRecruitStatusText(doc.getString("status"))
+                val hasInterview = doc.getBoolean("has_interview") ?: false
+
+                // Firestore Timestamp -> LocalDate
+                val start: LocalDate? = doc.getTimestamp("recruitment_start")?.toLocalDate()
+                val end: LocalDate? = doc.getTimestamp("recruitment_end")?.toLocalDate()
 
                 MyRecruitSummary(
                     id = doc.id,
-                    title = data["title"] as? String ?: "제목 없음",
-                    category = data["organization"] as? String ?: "단체명 없음",
-                    recruitStatus = getRecruitStatusText(data["status"] as? String),
-                    thumbnailUrl = thumbMap[doc.id], // 실제 이미지 URL
-                    hasInterview = data["has_interview"] as? Boolean ?: false,
+                    title = title,
+                    category = org,
+                    recruitStatus = status,
+                    thumbnailUrl = thumbMap[doc.id],
+                    hasInterview = hasInterview,
                     applicantCount = 0,
-                    recruitmentEnd = formatRecruitmentEnd(data["recruitment_end"])
+                    recruitmentStart = start,
+                    recruitmentEnd = end
                 )
             } catch (e: Exception) {
                 Log.e("MyRecruitsRemote", "내 공고 데이터 변환 실패: ${doc.id}", e)
@@ -51,17 +57,17 @@ object MyRecruitsRemote {
         }
     }
 
-    // 썸네일 이미지 조회 함수 추가
+    // 썸네일 조회 (post_images에서 order 0)
     private suspend fun fetchThumbnailByPostId(
         db: FirebaseFirestore,
         postIds: List<String>
     ): Map<String, String> = coroutineScope {
-        val chunks = postIds.chunked(10) // whereIn 최대 10개 제한
+        val chunks = postIds.chunked(10) // whereIn 제한
         val jobs = chunks.map { chunk ->
             async {
                 db.collection("post_images")
                     .whereIn("post_id", chunk)
-                    .whereEqualTo("image_order", 0) // 첫 번째 이미지만
+                    .whereEqualTo("image_order", 0)
                     .get()
                     .await()
                     .documents
@@ -74,35 +80,41 @@ object MyRecruitsRemote {
         }
         jobs.awaitAll().flatten().toMap()
     }
-    suspend fun getAppliedRecruits(): List<AppliedRecruitSummary> {
+
+    suspend fun getAppliedRecruits(currentUserId: String): List<AppliedRecruitSummary> {
         val db = FirebaseFirestore.getInstance()
 
         val applicationsSnap = db.collection("applications")
-            .whereEqualTo("applicant_user_id", myAppliedUserId)
+            .whereEqualTo("applicant_user_id", currentUserId)
             .get()
             .await()
 
-        // post_id 목록 추출
-        val postIds = applicationsSnap.documents.mapNotNull { doc ->
-            doc.data?.get("post_id") as? String
-        }.distinct()
+        // post_id 목록
+        val postIds = applicationsSnap.documents.mapNotNull { it.getString("post_id") }.distinct()
 
-        // 썸네일 이미지 조회
+        // 썸네일 맵
         val thumbMap = fetchThumbnailByPostId(db, postIds)
+
+        // posts 메타(상태/모집기간) 맵
+        val postMeta = fetchPostsMetaByIds(db, postIds)
 
         return applicationsSnap.documents.mapNotNull { doc ->
             try {
                 val data = doc.data ?: return@mapNotNull null
                 val postId = data["post_id"] as? String ?: return@mapNotNull null
-                val postTitle = data["post_title"] as? String ?: "공고 제목"
-                val postOrganization = data["post_organization"] as? String ?: "단체명"
+
+                val title = data["post_title"] as? String ?: "공고 제목"
+                val org = data["post_organization"] as? String ?: "단체명"
+
+                val meta = postMeta[postId]
+                val recruitStatus = getRecruitStatusText(meta?.status)
 
                 AppliedRecruitSummary(
                     id = doc.id,
                     postId = postId,
-                    title = postTitle,
-                    category = postOrganization,
-                    recruitStatus = "모집중",
+                    title = title,
+                    category = org,
+                    recruitStatus = recruitStatus,
                     applicationStatus = getApplicationStatusText(
                         data["status"] as? String,
                         data["is_passed"] as? Boolean
@@ -113,7 +125,10 @@ object MyRecruitsRemote {
                         data["status"] as? String,
                         data["interview_slot_id"] as? String
                     ),
-                    thumbnailUrl = thumbMap[postId] // 이미지 URL 추가
+                    thumbnailUrl = thumbMap[postId],
+
+                    recruitmentStart = meta?.recruitmentStart,
+                    recruitmentEnd = meta?.recruitmentEnd
                 )
             } catch (e: Exception) {
                 Log.e("MyRecruitsRemote", "지원한 공고 데이터 변환 실패: ${doc.id}", e)
@@ -122,7 +137,7 @@ object MyRecruitsRemote {
         }
     }
 
-    suspend fun getScheduleGroups(): List<ScheduleGroupSummary> {
+    suspend fun getScheduleGroups(currentUserId: String): List<ScheduleGroupSummary> {
         return emptyList()
     }
 
@@ -151,16 +166,34 @@ object MyRecruitsRemote {
         return status == "면접 대기 중" && interviewSlotId == null
     }
 
-    private fun formatRecruitmentEnd(recruitmentEnd: Any?): String? {
-        return try {
-            when (recruitmentEnd) {
-                is com.google.firebase.Timestamp -> {
-                    SimpleDateFormat("MM월 dd일", Locale.getDefault()).format(recruitmentEnd.toDate())
-                }
-                else -> null
+    private suspend fun fetchPostsMetaByIds(
+        db: FirebaseFirestore,
+        postIds: List<String>
+    ): Map<String, PostMeta> = coroutineScope {
+        if (postIds.isEmpty()) return@coroutineScope emptyMap()
+        val chunks = postIds.chunked(10)
+        val jobs = chunks.map { chunk ->
+            async {
+                db.collection("posts")
+                    .whereIn(FieldPath.documentId(), chunk)
+                    .get()
+                    .await()
+                    .documents
+                    .map { d ->
+                        val status = d.getString("status")
+                        val start: LocalDate? = d.getTimestamp("recruitment_start")?.toLocalDate()
+                        val end: LocalDate? = d.getTimestamp("recruitment_end")?.toLocalDate()
+                        d.id to PostMeta(status, start, end)
+                    }
             }
-        } catch (e: Exception) {
-            null
         }
+        jobs.awaitAll().flatten().toMap()
     }
+
+    // 내부용 메타
+    private data class PostMeta(
+        val status: String?,
+        val recruitmentStart: LocalDate?,
+        val recruitmentEnd: LocalDate?
+    )
 }

--- a/app/src/main/java/com/baek/untitledproject/data/repository/ApplicantRepositoryImpl.kt
+++ b/app/src/main/java/com/baek/untitledproject/data/repository/ApplicantRepositoryImpl.kt
@@ -4,14 +4,20 @@ import android.util.Log
 import com.baek.untitledproject.data.remote.ApplicantRemote
 import com.baek.untitledproject.domain.data.ApplicantSummary
 import com.baek.untitledproject.domain.repository.ApplicantRepository
+import com.baek.untitledproject.domain.repository.SessionRepository
 import com.baek.untitledproject.domain.utils.Result
 import javax.inject.Inject
 
-class ApplicantRepositoryImpl @Inject constructor() : ApplicantRepository {
+class ApplicantRepositoryImpl @Inject constructor(
+    private val sessionRepository: SessionRepository
+) : ApplicantRepository {
 
     override suspend fun getApplicants(postId: String): List<ApplicantSummary> {
         return try {
-            val result = ApplicantRemote.getApplicants(postId)
+            val currentUserId = sessionRepository.currentUid()
+                ?: throw IllegalStateException("로그인이 필요합니다")
+
+            val result = ApplicantRemote.getApplicants(postId, currentUserId)
             Log.d("ApplicantRepository", "Repository에서 수신: ${result.size}개")
             result.forEach { applicant ->
                 Log.d("ApplicantRepository", "Repository 데이터: ${applicant.name}")
@@ -45,12 +51,14 @@ class ApplicantRepositoryImpl @Inject constructor() : ApplicantRepository {
 
     override suspend fun scheduleInterviews(applicationIds: List<String>): Result<Unit> {
         return try {
-            ApplicantRemote.scheduleInterviews(applicationIds)
+            val currentUserId = sessionRepository.currentUid()
+                ?: return Result.Error("로그인이 필요합니다.", IllegalStateException())
+
+            ApplicantRemote.scheduleInterviews(applicationIds, currentUserId)
             Log.d("ApplicantRepository", "면접 일정 설정 완료: $applicationIds")
             Result.Success(Unit)
         } catch (e: Exception) {
             Log.e("ApplicantRepository", "면접 일정 설정 실패", e)
-            // 에러 메시지 구분해서 반환
             val errorMessage = when {
                 e.message?.contains("면접 일정이 설정되지 않았습니다") == true ->
                     "면접 일정이 설정되지 않았습니다. 먼저 면접 일정을 설정해주세요."
@@ -95,7 +103,13 @@ class ApplicantRepositoryImpl @Inject constructor() : ApplicantRepository {
 
     override suspend fun notifyResults(applicationIds: List<String>): Result<Unit> {
         return try {
-            ApplicantRemote.notifyResults(applicationIds)
+            val currentUserId = sessionRepository.currentUid()
+            if (currentUserId == null) {
+                Log.w("ApplicantRepository", "로그인되지 않음 - 알림 발송 불가")
+                return Result.Error("로그인이 필요합니다.", IllegalStateException())
+            }
+
+            ApplicantRemote.notifyResults(applicationIds, currentUserId)
             Log.d("ApplicantRepository", "결과 알림 발송 완료: $applicationIds")
             Result.Success(Unit)
         } catch (e: Exception) {

--- a/app/src/main/java/com/baek/untitledproject/data/repository/MyRecruitsRepositoryImpl.kt
+++ b/app/src/main/java/com/baek/untitledproject/data/repository/MyRecruitsRepositoryImpl.kt
@@ -8,13 +8,19 @@ import com.baek.untitledproject.domain.data.InterviewSlot
 import com.baek.untitledproject.domain.data.MyRecruitSummary
 import com.baek.untitledproject.domain.data.ScheduleGroupSummary
 import com.baek.untitledproject.domain.repository.MyRecruitsRepository
+import com.baek.untitledproject.domain.repository.SessionRepository
 import javax.inject.Inject
 
-class MyRecruitsRepositoryImpl @Inject constructor() : MyRecruitsRepository {
+class MyRecruitsRepositoryImpl @Inject constructor(
+    private val sessionRepository: SessionRepository
+) : MyRecruitsRepository {
 
     override suspend fun getMyRecruits(): List<MyRecruitSummary> {
         return try {
-            MyRecruitsRemote.getMyRecruits()
+            val currentUserId = sessionRepository.currentUid()
+                ?: throw IllegalStateException("로그인이 필요합니다")
+
+            MyRecruitsRemote.getMyRecruits(currentUserId)
         } catch (e: Exception) {
             Log.e("MyRecruitsRepository", "내 공고 목록 조회 실패", e)
             emptyList()
@@ -23,7 +29,10 @@ class MyRecruitsRepositoryImpl @Inject constructor() : MyRecruitsRepository {
 
     override suspend fun getAppliedRecruits(): List<AppliedRecruitSummary> {
         return try {
-            MyRecruitsRemote.getAppliedRecruits()
+            val currentUserId = sessionRepository.currentUid()
+                ?: throw IllegalStateException("로그인이 필요합니다")
+
+            MyRecruitsRemote.getAppliedRecruits(currentUserId)
         } catch (e: Exception) {
             Log.e("MyRecruitsRepository", "지원한 공고 목록 조회 실패", e)
             emptyList()
@@ -32,7 +41,13 @@ class MyRecruitsRepositoryImpl @Inject constructor() : MyRecruitsRepository {
 
     override suspend fun getScheduleGroups(): List<ScheduleGroupSummary> {
         return try {
-            MyRecruitsRemote.getScheduleGroups()
+            val currentUserId = sessionRepository.currentUid()
+            if (currentUserId == null) {
+                Log.w("MyRecruitsRepository", "로그인되지 않음 - 빈 리스트 반환")
+                return emptyList()
+            }
+
+            MyRecruitsRemote.getScheduleGroups(currentUserId) // userId 전달
         } catch (e: Exception) {
             Log.e("MyRecruitsRepository", "면접 일정 조회 실패", e)
             emptyList()

--- a/app/src/main/java/com/baek/untitledproject/domain/data/AppliedRecruitSummary.kt
+++ b/app/src/main/java/com/baek/untitledproject/domain/data/AppliedRecruitSummary.kt
@@ -1,16 +1,20 @@
 package com.baek.untitledproject.domain.data
 
+import java.time.LocalDate
+
 data class AppliedRecruitSummary(
-    val id: String,                          // application_id
-    val postId: String,                      // post_id
-    val title: String,                       // post_title (비정규화)
-    val category: String,                    // post_organization (비정규화)
-    val recruitStatus: String,               // 공고 상태 (posts.status에서 조회)
-    val applicationStatus: String,           // 지원 상태 (applications.status + is_passed 조합)
+    val id: String,
+    val postId: String,
+    val title: String,
+    val category: String,
+    val recruitStatus: String,
+    val applicationStatus: String,
     val thumbnailUrl: String? = null,
 
-    // 면접 관련 정보
-    val hasInterview: Boolean = false,       // 면접 있는 공고인지 (posts.has_interview에서 조회)
-    val interviewSlotId: String? = null,     // interview_slot_id
-    val canReserveInterview: Boolean = false // 면접 예약 가능 여부 (계산된 값)
+    val hasInterview: Boolean = false,
+    val interviewSlotId: String? = null,
+    val canReserveInterview: Boolean = false,
+
+    val recruitmentStart: LocalDate? = null,
+    val recruitmentEnd: LocalDate? = null
 )

--- a/app/src/main/java/com/baek/untitledproject/domain/data/MyRecruitSummary.kt
+++ b/app/src/main/java/com/baek/untitledproject/domain/data/MyRecruitSummary.kt
@@ -1,14 +1,17 @@
 package com.baek.untitledproject.domain.data
 
-data class MyRecruitSummary(
-    val id: String,                          // post_id
-    val title: String,                       // title
-    val category: String,                    // organization (단체명을 카테고리로 사용)
-    val recruitStatus: String,               // status ("recruiting" -> "모집중", "completed" -> "모집완료")
-    val thumbnailUrl: String? = null,        // 첫 번째 이미지 (post_images에서 조회)
+import java.time.LocalDate
 
-    // 관리용 정보
-    val hasInterview: Boolean,               // has_interview
-    val applicantCount: Int = 0,             // 지원자 수 (applications 컬렉션에서 계산)
-    val recruitmentEnd: String? = null       // recruitment_end (포맷된 날짜)
+data class MyRecruitSummary(
+    val id: String,
+    val title: String,
+    val category: String,
+    val recruitStatus: String,
+    val thumbnailUrl: String? = null,
+
+    val hasInterview: Boolean,
+    val applicantCount: Int = 0,
+
+    val recruitmentStart: LocalDate? = null,
+    val recruitmentEnd: LocalDate? = null
 )

--- a/app/src/main/java/com/baek/untitledproject/ui/recruit/AppliedRecruitAdapter.kt
+++ b/app/src/main/java/com/baek/untitledproject/ui/recruit/AppliedRecruitAdapter.kt
@@ -6,15 +6,19 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.baek.untitledproject.databinding.ItemAppliedRecruitCardBinding
+import com.baek.untitledproject.databinding.ItemEmptyStateCardBinding
 import com.baek.untitledproject.domain.data.AppliedRecruitSummary
 
 class AppliedRecruitAdapter(
     private val onInterviewReserveClick: (String) -> Unit,
     private val onViewPostClick: (String) -> Unit,
     private val onCardClick: (String) -> Unit = {}
-) : ListAdapter<AppliedRecruitSummary, AppliedRecruitAdapter.AppliedRecruitViewHolder>(AppliedRecruitDiffCallback) {
+) : ListAdapter<AppliedRecruitSummary, RecyclerView.ViewHolder>(AppliedRecruitDiffCallback) {
 
     companion object {
+        private const val VIEW_TYPE_NORMAL = 0
+        private const val VIEW_TYPE_EMPTY = 1
+
         private val AppliedRecruitDiffCallback = object : DiffUtil.ItemCallback<AppliedRecruitSummary>() {
             override fun areItemsTheSame(
                 oldItem: AppliedRecruitSummary,
@@ -29,6 +33,60 @@ class AppliedRecruitAdapter(
             ): Boolean {
                 return oldItem == newItem
             }
+        }
+    }
+
+    override fun getItemViewType(position: Int): Int {
+        return if (currentList.isEmpty()) {
+            VIEW_TYPE_EMPTY
+        } else {
+            VIEW_TYPE_NORMAL
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return if (currentList.isEmpty()) 1 else currentList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            VIEW_TYPE_EMPTY -> {
+                val binding = ItemEmptyStateCardBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+                EmptyViewHolder(binding)
+            }
+            else -> {
+                val binding = ItemAppliedRecruitCardBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+                AppliedRecruitViewHolder(binding)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is EmptyViewHolder -> {
+                holder.bind()
+            }
+            is AppliedRecruitViewHolder -> {
+                holder.bind(currentList[position])
+            }
+        }
+    }
+
+    inner class EmptyViewHolder(
+        private val binding: ItemEmptyStateCardBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind() {
+            binding.emptyTitle.text = "지원한 공고가 없습니다"
+            binding.emptyDescription.text = "관심있는 공고에 지원해보세요"
         }
     }
 
@@ -63,18 +121,5 @@ class AppliedRecruitAdapter(
                 onViewPostClick(item.id)
             }
         }
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AppliedRecruitViewHolder {
-        val binding = ItemAppliedRecruitCardBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
-        )
-        return AppliedRecruitViewHolder(binding)
-    }
-
-    override fun onBindViewHolder(holder: AppliedRecruitViewHolder, position: Int) {
-        holder.bind(getItem(position))
     }
 }

--- a/app/src/main/java/com/baek/untitledproject/ui/recruit/MyRecruitAdapter.kt
+++ b/app/src/main/java/com/baek/untitledproject/ui/recruit/MyRecruitAdapter.kt
@@ -1,12 +1,12 @@
 package com.baek.untitledproject.ui.recruit.adapter
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.baek.untitledproject.databinding.ItemMyRecruitCardBinding
+import com.baek.untitledproject.databinding.ItemEmptyStateCardBinding
 import com.baek.untitledproject.domain.data.MyRecruitSummary
 
 class MyRecruitAdapter(
@@ -14,9 +14,12 @@ class MyRecruitAdapter(
     private val onApplicantManageClick: (String) -> Unit,
     private val onPostManageClick: (String) -> Unit,
     private val onCardClick: (String) -> Unit = {}
-) : ListAdapter<MyRecruitSummary, MyRecruitAdapter.MyRecruitViewHolder>(MyRecruitDiffCallback) {
+) : ListAdapter<MyRecruitSummary, RecyclerView.ViewHolder>(MyRecruitDiffCallback) {
 
     companion object {
+        private const val VIEW_TYPE_NORMAL = 0
+        private const val VIEW_TYPE_EMPTY = 1
+
         private val MyRecruitDiffCallback = object : DiffUtil.ItemCallback<MyRecruitSummary>() {
             override fun areItemsTheSame(
                 oldItem: MyRecruitSummary,
@@ -34,6 +37,60 @@ class MyRecruitAdapter(
         }
     }
 
+    override fun getItemViewType(position: Int): Int {
+        return if (currentList.isEmpty()) {
+            VIEW_TYPE_EMPTY
+        } else {
+            VIEW_TYPE_NORMAL
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return if (currentList.isEmpty()) 1 else currentList.size
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+        return when (viewType) {
+            VIEW_TYPE_EMPTY -> {
+                val binding = ItemEmptyStateCardBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+                EmptyViewHolder(binding)
+            }
+            else -> {
+                val binding = ItemMyRecruitCardBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+                MyRecruitViewHolder(binding)
+            }
+        }
+    }
+
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is EmptyViewHolder -> {
+                holder.bind()
+            }
+            is MyRecruitViewHolder -> {
+                holder.bind(currentList[position])
+            }
+        }
+    }
+
+    inner class EmptyViewHolder(
+        private val binding: ItemEmptyStateCardBinding
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind() {
+            binding.emptyTitle.text = "올린 공고가 없습니다"
+            binding.emptyDescription.text = "새로운 채용 공고를 작성해보세요"
+        }
+    }
+
     inner class MyRecruitViewHolder(
         private val binding: ItemMyRecruitCardBinding
     ) : RecyclerView.ViewHolder(binding.root) {
@@ -44,11 +101,8 @@ class MyRecruitAdapter(
             binding.titleTxt.text = item.title
             binding.statusTxt.text = item.recruitStatus
 
-            // 썸네일 이미지 설정
+            // 인테일 이미지 설정
             // TODO: Glide 또는 Coil로 이미지 로딩
-            // Glide.with(binding.root.context)
-            //     .load(item.thumbnailUrl)
-            //     .into(binding.thumbnailImg)
 
             // 버튼 클릭 이벤트
             setupButtonClickEvents(item)
@@ -72,18 +126,5 @@ class MyRecruitAdapter(
                 onPostManageClick(item.id)
             }
         }
-    }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyRecruitViewHolder {
-        val binding = ItemMyRecruitCardBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
-        )
-        return MyRecruitViewHolder(binding)
-    }
-
-    override fun onBindViewHolder(holder: MyRecruitViewHolder, position: Int) {
-        holder.bind(getItem(position))
     }
 }

--- a/app/src/main/java/com/baek/untitledproject/ui/recruit/MyRecruitsFragment.kt
+++ b/app/src/main/java/com/baek/untitledproject/ui/recruit/MyRecruitsFragment.kt
@@ -8,14 +8,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
+import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.viewpager2.widget.ViewPager2
+import com.baek.untitledproject.R
 import com.baek.untitledproject.databinding.FragmentMyRecruitsBinding
+import com.baek.untitledproject.ui.MainActivity
 import com.baek.untitledproject.ui.recruit.adapter.AppliedRecruitPagerAdapter
 import com.baek.untitledproject.ui.recruit.adapter.MyRecruitPagerAdapter
 import com.baek.untitledproject.ui.recruit.adapter.ScheduleGroupAdapter
@@ -54,6 +58,14 @@ class MyRecruitsFragment : Fragment() {
         viewModel.loadAllData()
     }
 
+    override fun onResume() {
+        super.onResume()
+        (activity as? MainActivity)?.setToolbar(
+            detailVisible = true,
+            title = "내 공고 관리"
+        )
+    }
+
     private fun initAdapters() {
         // 일정 그룹 어댑터
         scheduleGroupAdapter = ScheduleGroupAdapter { groupId ->
@@ -62,8 +74,11 @@ class MyRecruitsFragment : Fragment() {
 
         // 내 공고 ViewPager2 어댑터
         myRecruitPagerAdapter = MyRecruitPagerAdapter(
-            onInterviewManageClick = { recruitId ->
-                viewModel.onInterviewManageClick(recruitId)
+            onInterviewManageClick = { postId ->
+                findNavController().navigate(
+                    R.id.write_board_nav_graph,
+                    bundleOf("postId" to postId)
+                )
             },
             onApplicantManageClick = { recruitId ->
                 val intent = Intent(requireContext(), ApplicantManagementActivity::class.java)
@@ -71,7 +86,9 @@ class MyRecruitsFragment : Fragment() {
                 startActivity(intent)
             },
             onPostManageClick = { recruitId ->
-                viewModel.onPostManageClick(recruitId)
+                // 공고 상세보기로 이동
+                val bundle = bundleOf("id" to recruitId)
+                findNavController().navigate(R.id.boardDetailFragment, bundle)
             },
             onCardClick = { recruitId ->
                 // TODO: 상세 페이지로 이동
@@ -80,7 +97,6 @@ class MyRecruitsFragment : Fragment() {
 
         appliedRecruitPagerAdapter = AppliedRecruitPagerAdapter(
             onInterviewReserveClick = { recruitId ->
-
                 val appliedRecruit = viewModel.appliedRecruits.value.find { it.id == recruitId }
 
                 if (appliedRecruit != null) {
@@ -95,7 +111,13 @@ class MyRecruitsFragment : Fragment() {
                 }
             },
             onViewPostClick = { recruitId ->
-                viewModel.onViewPostClick(recruitId)
+                val appliedRecruit = viewModel.appliedRecruits.value.find { it.id == recruitId }
+                if (appliedRecruit != null) {
+                    val bundle = bundleOf("id" to appliedRecruit.postId)
+                    findNavController().navigate(R.id.boardDetailFragment, bundle)
+                } else {
+                    Toast.makeText(requireContext(), "공고를 찾을 수 없습니다.", Toast.LENGTH_SHORT).show()
+                }
             },
             onCardClick = { recruitId ->
                 // TODO: 상세 페이지로 이동
@@ -145,7 +167,7 @@ class MyRecruitsFragment : Fragment() {
             adapter = appliedRecruitPagerAdapter
             orientation = ViewPager2.ORIENTATION_HORIZONTAL
 
-            // 부드러운 페이지 전환을 위한 설정
+            // 부드러운 페이지 전환
             offscreenPageLimit = 1
 
             // 페이지 변경 리스너 등록
@@ -168,25 +190,43 @@ class MyRecruitsFragment : Fragment() {
                     }
                 }
 
-                // 내 공고 관찰
+                // 내 공고 관찰 - 빈 상태 처리 추가
                 launch {
                     viewModel.myRecruits.collect { myRecruits ->
-                        myRecruitPagerAdapter.submitList(myRecruits)
-                        // 개수 업데이트
-                        binding.myRecruitCountTxt.text = myRecruits.size.toString()
-                        // 인디케이터 설정
-                        setupMyRecruitIndicator(myRecruits.size)
+                        if (myRecruits.isEmpty()) {
+                            // 빈 상태: ViewPager 숨기고 빈 상태 뷰 표시
+                            binding.myRecruitViewPager.visibility = View.GONE
+                            binding.myRecruitIndicator.visibility = View.GONE
+                            binding.myRecruitEmptyView.visibility = View.VISIBLE
+                            binding.myRecruitCountTxt.text = "0"
+                        } else {
+                            // 데이터 있음: 정상 표시
+                            binding.myRecruitViewPager.visibility = View.VISIBLE
+                            binding.myRecruitEmptyView.visibility = View.GONE
+                            myRecruitPagerAdapter.submitList(myRecruits)
+                            binding.myRecruitCountTxt.text = myRecruits.size.toString()
+                            setupMyRecruitIndicator(myRecruits.size)
+                        }
                     }
                 }
 
-                // 지원한 공고 관찰
+                // 지원한 공고 관찰 - 빈 상태 처리 추가
                 launch {
                     viewModel.appliedRecruits.collect { appliedRecruits ->
-                        appliedRecruitPagerAdapter.submitList(appliedRecruits)
-                        // 개수 업데이트
-                        binding.appliedRecruitCountTxt.text = appliedRecruits.size.toString()
-                        // 인디케이터 설정
-                        setupAppliedRecruitIndicator(appliedRecruits.size)
+                        if (appliedRecruits.isEmpty()) {
+                            // 빈 상태: ViewPager 숨기고 빈 상태 뷰 표시
+                            binding.appliedRecruitViewPager.visibility = View.GONE
+                            binding.appliedRecruitIndicator.visibility = View.GONE
+                            binding.appliedRecruitEmptyView.visibility = View.VISIBLE
+                            binding.appliedRecruitCountTxt.text = "0"
+                        } else {
+                            // 데이터 있음: 정상 표시
+                            binding.appliedRecruitViewPager.visibility = View.VISIBLE
+                            binding.appliedRecruitEmptyView.visibility = View.GONE
+                            appliedRecruitPagerAdapter.submitList(appliedRecruits)
+                            binding.appliedRecruitCountTxt.text = appliedRecruits.size.toString()
+                            setupAppliedRecruitIndicator(appliedRecruits.size)
+                        }
                     }
                 }
 

--- a/app/src/main/java/com/baek/untitledproject/ui/recruit/adapter/AppliedRecruitPagerAdapter.kt
+++ b/app/src/main/java/com/baek/untitledproject/ui/recruit/adapter/AppliedRecruitPagerAdapter.kt
@@ -1,6 +1,7 @@
 package com.baek.untitledproject.ui.recruit.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,6 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.baek.untitledproject.databinding.ItemAppliedRecruitCardBinding
 import com.baek.untitledproject.domain.data.AppliedRecruitSummary
 import com.bumptech.glide.Glide
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class AppliedRecruitPagerAdapter(
     private val onInterviewReserveClick: (String) -> Unit,
@@ -17,20 +20,12 @@ class AppliedRecruitPagerAdapter(
 
     companion object {
         private val AppliedRecruitDiffCallback = object : DiffUtil.ItemCallback<AppliedRecruitSummary>() {
-            override fun areItemsTheSame(
-                oldItem: AppliedRecruitSummary,
-                newItem: AppliedRecruitSummary
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
-
-            override fun areContentsTheSame(
-                oldItem: AppliedRecruitSummary,
-                newItem: AppliedRecruitSummary
-            ): Boolean {
-                return oldItem == newItem
-            }
+            override fun areItemsTheSame(oldItem: AppliedRecruitSummary, newItem: AppliedRecruitSummary) =
+                oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: AppliedRecruitSummary, newItem: AppliedRecruitSummary) =
+                oldItem == newItem
         }
+        private val mdFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREA)
     }
 
     inner class AppliedRecruitViewHolder(
@@ -38,7 +33,12 @@ class AppliedRecruitPagerAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: AppliedRecruitSummary) {
-            // 썸네일 이미지 설정
+            // 기본 정보
+            binding.categoryTxt.text = item.category
+            binding.titleTxt.text = item.title
+            binding.statusTxt.text = item.recruitStatus
+
+            // 썸네일
             if (!item.thumbnailUrl.isNullOrEmpty()) {
                 Glide.with(binding.root.context)
                     .load(item.thumbnailUrl)
@@ -49,31 +49,26 @@ class AppliedRecruitPagerAdapter(
                 binding.thumbnailImg.setImageResource(android.R.color.darker_gray)
             }
 
-            // 버튼 클릭 이벤트 설정
-            setupButtonClickEvents(item)
-
-            // 카드 클릭 이벤트
-            binding.root.setOnClickListener {
-                onCardClick(item.id)
-            }
-        }
-
-        private fun setupButtonClickEvents(item: AppliedRecruitSummary) {
-            binding.interviewReserveBtn.setOnClickListener {
-                onInterviewReserveClick(item.id)
+            // 모집 기간: 둘 다 있을 때만 "M월 d일 ~ M월 d일"
+            val s = item.recruitmentStart
+            val e = item.recruitmentEnd
+            if (s != null && e != null) {
+                binding.periodRow.visibility = View.VISIBLE
+                binding.periodDetailTxt.text = "${s.format(mdFormatter)} ~ ${e.format(mdFormatter)}"
+            } else {
+                binding.periodRow.visibility = View.GONE
             }
 
-            binding.viewPostBtn.setOnClickListener {
-                onViewPostClick(item.id)
-            }
+            // 클릭
+            binding.interviewReserveBtn.setOnClickListener { onInterviewReserveClick(item.id) }
+            binding.viewPostBtn.setOnClickListener { onViewPostClick(item.id) }
+            binding.root.setOnClickListener { onCardClick(item.id) }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AppliedRecruitViewHolder {
         val binding = ItemAppliedRecruitCardBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
+            LayoutInflater.from(parent.context), parent, false
         )
         return AppliedRecruitViewHolder(binding)
     }

--- a/app/src/main/java/com/baek/untitledproject/ui/recruit/adapter/MyRecruitPagerAdapter.kt
+++ b/app/src/main/java/com/baek/untitledproject/ui/recruit/adapter/MyRecruitPagerAdapter.kt
@@ -1,6 +1,7 @@
 package com.baek.untitledproject.ui.recruit.adapter
 
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
@@ -8,6 +9,8 @@ import androidx.recyclerview.widget.RecyclerView
 import com.baek.untitledproject.databinding.ItemMyRecruitCardBinding
 import com.baek.untitledproject.domain.data.MyRecruitSummary
 import com.bumptech.glide.Glide
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 class MyRecruitPagerAdapter(
     private val onInterviewManageClick: (String) -> Unit,
@@ -18,20 +21,12 @@ class MyRecruitPagerAdapter(
 
     companion object {
         private val MyRecruitDiffCallback = object : DiffUtil.ItemCallback<MyRecruitSummary>() {
-            override fun areItemsTheSame(
-                oldItem: MyRecruitSummary,
-                newItem: MyRecruitSummary
-            ): Boolean {
-                return oldItem.id == newItem.id
-            }
-
-            override fun areContentsTheSame(
-                oldItem: MyRecruitSummary,
-                newItem: MyRecruitSummary
-            ): Boolean {
-                return oldItem == newItem
-            }
+            override fun areItemsTheSame(oldItem: MyRecruitSummary, newItem: MyRecruitSummary) =
+                oldItem.id == newItem.id
+            override fun areContentsTheSame(oldItem: MyRecruitSummary, newItem: MyRecruitSummary) =
+                oldItem == newItem
         }
+        private val mdFormatter = DateTimeFormatter.ofPattern("M월 d일", Locale.KOREA)
     }
 
     inner class MyRecruitViewHolder(
@@ -39,12 +34,12 @@ class MyRecruitPagerAdapter(
     ) : RecyclerView.ViewHolder(binding.root) {
 
         fun bind(item: MyRecruitSummary) {
-            // 기본 정보 설정
+            // 기본 정보
             binding.categoryTxt.text = item.category
             binding.titleTxt.text = item.title
             binding.statusTxt.text = item.recruitStatus
 
-            // 썸네일 이미지 설정
+            // 썸네일
             if (!item.thumbnailUrl.isNullOrEmpty()) {
                 Glide.with(binding.root.context)
                     .load(item.thumbnailUrl)
@@ -55,35 +50,27 @@ class MyRecruitPagerAdapter(
                 binding.thumbnailImg.setImageResource(android.R.color.darker_gray)
             }
 
-            // 버튼 클릭 이벤트
-            setupButtonClickEvents(item)
-
-            // 카드 클릭 이벤트
-            binding.root.setOnClickListener {
-                onCardClick(item.id)
-            }
-        }
-
-        private fun setupButtonClickEvents(item: MyRecruitSummary) {
-            binding.interviewManageBtn.setOnClickListener {
-                onInterviewManageClick(item.id)
+            // 모집 기간: 둘 다 있을 때만 "M월 d일 ~ M월 d일"
+            val s = item.recruitmentStart
+            val e = item.recruitmentEnd
+            if (s != null && e != null) {
+                binding.periodRow.visibility = View.VISIBLE
+                binding.periodDetailTxt.text = "${s.format(mdFormatter)} ~ ${e.format(mdFormatter)}"
+            } else {
+                binding.periodRow.visibility = View.GONE
             }
 
-            binding.applicantManageBtn.setOnClickListener {
-                onApplicantManageClick(item.id)
-            }
-
-            binding.postManageBtn.setOnClickListener {
-                onPostManageClick(item.id)
-            }
+            // 클릭
+            binding.interviewManageBtn.setOnClickListener { onInterviewManageClick(item.id) }
+            binding.applicantManageBtn.setOnClickListener { onApplicantManageClick(item.id) }
+            binding.postManageBtn.setOnClickListener { onPostManageClick(item.id) }
+            binding.root.setOnClickListener { onCardClick(item.id) }
         }
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MyRecruitViewHolder {
         val binding = ItemMyRecruitCardBinding.inflate(
-            LayoutInflater.from(parent.context),
-            parent,
-            false
+            LayoutInflater.from(parent.context), parent, false
         )
         return MyRecruitViewHolder(binding)
     }

--- a/app/src/main/res/layout/fragment_my_recruits.xml
+++ b/app/src/main/res/layout/fragment_my_recruits.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -23,7 +24,7 @@
             android:textSize="18sp"
             android:textStyle="bold" />
 
-        <!-- 일정 목록 (기존 RecyclerView 유지) -->
+        <!-- 일정 목록 -->
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/scheduleRecyclerView"
             android:layout_width="match_parent"
@@ -65,6 +66,56 @@
             android:layout_width="match_parent"
             android:layout_height="280dp"
             android:layout_marginBottom="4dp" />
+
+        <!-- 내 공고 빈 상태 뷰 -->
+        <LinearLayout
+            android:id="@+id/myRecruitEmptyView"
+            android:layout_width="match_parent"
+            android:layout_height="280dp"
+            android:layout_marginBottom="4dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="8dp"
+            android:visibility="gone">
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="240dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp"
+                app:cardBackgroundColor="#FFFFFF"
+                app:contentPadding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:gravity="center">
+
+                    <!-- 메인 메시지 -->
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="올린 공고가 없습니다"
+                        android:textColor="#666666"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:gravity="center" />
+
+                    <!-- 부가 설명 -->
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="새로운 채용 공고를 작성해보세요"
+                        android:textColor="#999999"
+                        android:textSize="14sp"
+                        android:gravity="center" />
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+        </LinearLayout>
 
         <!-- 내 공고 페이지 인디케이터 -->
         <LinearLayout
@@ -110,6 +161,56 @@
             android:layout_width="match_parent"
             android:layout_height="280dp"
             android:layout_marginBottom="4dp" />
+
+        <!-- 지원한 공고 빈 상태 뷰 -->
+        <LinearLayout
+            android:id="@+id/appliedRecruitEmptyView"
+            android:layout_width="match_parent"
+            android:layout_height="280dp"
+            android:layout_marginBottom="4dp"
+            android:paddingHorizontal="16dp"
+            android:paddingVertical="8dp"
+            android:visibility="gone">
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="240dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="2dp"
+                app:cardBackgroundColor="#FFFFFF"
+                app:contentPadding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical"
+                    android:gravity="center">
+
+                    <!-- 메인 메시지 -->
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="지원한 공고가 없습니다"
+                        android:textColor="#666666"
+                        android:textSize="16sp"
+                        android:textStyle="bold"
+                        android:gravity="center" />
+
+                    <!-- 부가 설명 -->
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="관심있는 공고에 지원해보세요"
+                        android:textColor="#999999"
+                        android:textSize="14sp"
+                        android:gravity="center" />
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+        </LinearLayout>
 
         <!-- 지원한 공고 페이지 인디케이터 -->
         <LinearLayout

--- a/app/src/main/res/layout/item_applied_recruit_card.xml
+++ b/app/src/main/res/layout/item_applied_recruit_card.xml
@@ -19,7 +19,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- 상단: 이미지 + 텍스트 가로 배치 -->
+            <!-- 상단: 썸네일 + 텍스트 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -27,7 +27,6 @@
                 android:orientation="horizontal"
                 android:gravity="top">
 
-                <!-- 좌측: 썸네일 이미지 -->
                 <ImageView
                     android:id="@+id/thumbnailImg"
                     android:layout_width="60dp"
@@ -36,40 +35,32 @@
                     android:background="#E0E0E0"
                     android:scaleType="centerCrop" />
 
-                <!-- 우측: 동아리명 + 제목 -->
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:orientation="vertical">
 
-                    <!-- 동아리명 -->
                     <TextView
                         android:id="@+id/categoryTxt"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="4dp"
-                        android:text="동아리명"
                         android:textColor="#666666"
                         android:textSize="12sp" />
 
-                    <!-- 제목 -->
                     <TextView
                         android:id="@+id/titleTxt"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="댄스 동아리 OO 모집합니다"
                         android:textColor="#333333"
                         android:textSize="16sp"
                         android:textStyle="bold"
                         android:maxLines="2"
                         android:ellipsize="end" />
-
                 </LinearLayout>
-
             </LinearLayout>
 
-            <!-- 상태 -->
             <TextView
                 android:id="@+id/statusTxt"
                 android:layout_width="wrap_content"
@@ -78,12 +69,12 @@
                 android:background="@drawable/tag_green"
                 android:paddingHorizontal="6dp"
                 android:paddingVertical="2dp"
-                android:text="모집중"
                 android:textColor="#4CAF50"
                 android:textSize="11sp" />
 
             <!-- 모집 기간 -->
             <LinearLayout
+                android:id="@+id/periodRow"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="2dp"
@@ -101,10 +92,9 @@
                     android:id="@+id/periodDetailTxt"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="8월 1일 ~ 9월 30일"
-                    android:textColor="#666666"
-                    android:textSize="12sp" />
-
+                    android:text=""
+                android:textColor="#666666"
+                android:textSize="12sp" />
             </LinearLayout>
 
             <!-- 현재 일정 -->
@@ -129,10 +119,9 @@
                     android:text="미정"
                     android:textColor="#666666"
                     android:textSize="12sp" />
-
             </LinearLayout>
 
-            <!-- 하단: 액션 버튼들 -->
+            <!-- 하단 버튼 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -161,11 +150,7 @@
                     android:text="공고글 보기"
                     android:textColor="#333333"
                     android:textSize="12sp" />
-
             </LinearLayout>
-
         </LinearLayout>
-
     </androidx.cardview.widget.CardView>
-
 </LinearLayout>

--- a/app/src/main/res/layout/item_empty_state_card.xml
+++ b/app/src/main/res/layout/item_empty_state_card.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingHorizontal="16dp"
+    android:paddingVertical="8dp">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="240dp"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="2dp"
+        app:cardBackgroundColor="#FFFFFF"
+        app:contentPadding="16dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            android:gravity="center">
+
+            <!-- 메인 메시지 -->
+            <TextView
+                android:id="@+id/emptyTitle"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="올린 공고가 없습니다"
+                android:textColor="#666666"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                android:gravity="center" />
+
+            <!-- 부가 설명 -->
+            <TextView
+                android:id="@+id/emptyDescription"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="새로운 채용 공고를 작성해보세요"
+                android:textColor="#999999"
+                android:textSize="14sp"
+                android:gravity="center" />
+
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_my_recruit_card.xml
+++ b/app/src/main/res/layout/item_my_recruit_card.xml
@@ -18,7 +18,7 @@
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <!-- 상단: 이미지 + 텍스트 가로 배치 -->
+            <!-- 상단: 썸네일 + 텍스트 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -26,7 +26,6 @@
                 android:orientation="horizontal"
                 android:gravity="top">
 
-                <!-- 좌측: 썸네일 이미지 -->
                 <ImageView
                     android:id="@+id/thumbnailImg"
                     android:layout_width="60dp"
@@ -35,40 +34,32 @@
                     android:background="#E0E0E0"
                     android:scaleType="centerCrop" />
 
-                <!-- 우측: 동아리명 + 제목 -->
                 <LinearLayout
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_weight="1"
                     android:orientation="vertical">
 
-                    <!-- 동아리명 -->
                     <TextView
                         android:id="@+id/categoryTxt"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="4dp"
-                        android:text="동아리명"
                         android:textColor="#666666"
                         android:textSize="12sp" />
 
-                    <!-- 제목 -->
                     <TextView
                         android:id="@+id/titleTxt"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:text="댄스 동아리 OO 모집합니다"
                         android:textColor="#333333"
                         android:textSize="16sp"
                         android:textStyle="bold"
                         android:maxLines="2"
                         android:ellipsize="end" />
-
                 </LinearLayout>
-
             </LinearLayout>
 
-            <!-- 상태 -->
             <TextView
                 android:id="@+id/statusTxt"
                 android:layout_width="wrap_content"
@@ -77,12 +68,12 @@
                 android:background="@drawable/tag_blue"
                 android:paddingHorizontal="6dp"
                 android:paddingVertical="2dp"
-                android:text="면접 진행"
                 android:textColor="#2196F3"
                 android:textSize="11sp" />
 
             <!-- 모집 기간 -->
             <LinearLayout
+                android:id="@+id/periodRow"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="2dp"
@@ -100,10 +91,9 @@
                     android:id="@+id/periodDetailTxt"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="8월 1일 ~ 9월 30일"
-                    android:textColor="#666666"
-                    android:textSize="12sp" />
-
+                    android:text=""
+                android:textColor="#666666"
+                android:textSize="12sp" />
             </LinearLayout>
 
             <!-- 현재 일정 -->
@@ -128,10 +118,9 @@
                     android:text="미정"
                     android:textColor="#666666"
                     android:textSize="12sp" />
-
             </LinearLayout>
 
-            <!-- 하단: 관리 버튼들 -->
+            <!-- 하단 버튼 -->
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -172,11 +161,7 @@
                     android:text="작성글 관리"
                     android:textColor="#333333"
                     android:textSize="12sp" />
-
             </LinearLayout>
-
         </LinearLayout>
-
     </androidx.cardview.widget.CardView>
-
 </LinearLayout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -30,7 +30,14 @@
         android:id="@+id/myRecruitsFragment"
         android:name="com.baek.untitledproject.ui.recruit.MyRecruitsFragment"
         android:label="fragment_my_recruits"
-        tools:layout="@layout/fragment_my_recruits" />
+        tools:layout="@layout/fragment_my_recruits">
+         <action
+            android:id="@+id/action_myRecruitsFragment_to_boardDetailFragment"
+            app:destination="@id/boardDetailFragment" />
+        <action
+            android:id="@+id/action_myRecruitsFragment_to_interviewScheduleFragment"
+            app:destination="@id/interviewScheduleFragment" />
+    </fragment>
     <fragment
         android:id="@+id/messageFragment"
         android:name="com.baek.untitledproject.ui.message.MessageFragment"
@@ -106,4 +113,5 @@
         android:name="com.baek.untitledproject.ui.setting.DeleteAccountFragment"
         android:label="fragment_delete_account"
         tools:layout="@layout/fragment_delete_account" />
+
 </navigation>


### PR DESCRIPTION
- 빈 상태 카드 구현 및 빈/데이터 분기 처리
- API/Repo 전반에 userId 파라미터 추가
- 공고 상태/모집기간/일정 Firestore 연동 (posts/apps + post_images)
- Repository 유저 정보 동기화 로직 추가
- 지원 공고 & 내가 올린 공고 일정 데이터/표시 추가
- 내 공고 일정 섹션 표시 및 UI 정리(리팩터링)